### PR TITLE
README: add a link to url-bot-rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ projects:
 - [irc-bot.rs][ircbot] — a library for writing IRC bots
 - [playbot_ng][playbot_ng] — a Rust-evaluating IRC bot in Rust
 - [bunnybutt-rs][bunnybutt] — an IRC bot for the [Feed The Beast Wiki][ftb-wiki]
+- [url-bot-rs][url-bot-rs] — a URL-fetching IRC bot
 
 [alectro]: https://github.com/aatxe/alectro
 [spilo]: https://github.com/aatxe/spilo
@@ -34,6 +35,7 @@ projects:
 [bunnybutt]: https://github.com/FTB-Gamepedia/bunnybutt-rs
 [playbot_ng]: https://github.com/panicbit/playbot_ng
 [ftb-wiki]: https://ftb.gamepedia.com/FTB_Wiki
+[url-bot-rs]: https://github.com/nuxeh/url-bot-rs
 
 Making your own project? [Submit a pull request](https://github.com/aatxe/irc/pulls) to add it!
 


### PR DESCRIPTION
Add a link to url-bot-rs, a project making use of this crate.